### PR TITLE
Update "Projects using Astrolabe"

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ ast.each_node
 
 ## Projects using Astrolabe
 
-* [RuboCop](https://github.com/bbatsov/rubocop)
 * [Transpec](https://github.com/yujinakayama/transpec)
 
 ## Compatibility


### PR DESCRIPTION
`RuboCop` does not currently use `astrolabe`. Indeed it now has it's corresponding `rubocop-ast` gem.